### PR TITLE
Remove import of ObjectiveC.NSObject for native builds

### DIFF
--- a/Sources/SkipXML/SkipXML.swift
+++ b/Sources/SkipXML/SkipXML.swift
@@ -11,7 +11,6 @@ import protocol Foundation.XMLParserDelegate
 import Foundation
 
 #if !SKIP
-import class ObjectiveC.NSObject
 typealias ParserDelegateType = XMLParserDelegate
 typealias LexicalDelegateType = NSObject
 typealias XMLParserType = XMLParser


### PR DESCRIPTION
Error: `/skip-xml/Sources/SkipXML/SkipXML.swift:14:14: error: no such module 'ObjectiveC'`

Not sure why `skip android build` would try to compile the native path (inside #if !SKIP) in a transpiled module? Either way, it doesn't seem like `import ObjectiveC .NSObject` is actually needed on any compile path so might as well remove it 

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

(Also ran `skip android build` successfully)

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

